### PR TITLE
Auto-reset difficut cards

### DIFF
--- a/koala/clean-string.ts
+++ b/koala/clean-string.ts
@@ -1,8 +1,0 @@
-const cleanString = (str: string) => {
-  // This regex matches any whitespace characters or punctuation
-  return str.replace(/[\s\.,\/#!$%\^&\*;:{}=\-_`~()]/g, "").toLowerCase();
-};
-
-export const exactMatch = (str: string, query: string) => {
-  return cleanString(str) === cleanString(query);
-};

--- a/koala/evenly-distribute.ts
+++ b/koala/evenly-distribute.ts
@@ -25,7 +25,7 @@ export function evenlyDistribute<
   return copy;
 }
 
-export const eligibleForLeveling = async (userID: string) => {
+const eligibleForLeveling = async (userID: string) => {
   const all = await prismaClient.quiz.findMany({
     where: {
       Card: {

--- a/koala/generate-speech-url.ts
+++ b/koala/generate-speech-url.ts
@@ -93,7 +93,9 @@ const randomVoice = (langCode: string, gender: string) => {
 
 const VERSION = "v1"; // Bust cache with this. Be careful with changing this.
 
-export async function generateSpeechURL(params: AudioLessonParams): Promise<string> {
+export async function generateSpeechURL(
+  params: AudioLessonParams,
+): Promise<string> {
   console.log(`Create audio: ${params.text}`);
 
   const lang = params.langCode.slice(0, 2).toLocaleLowerCase();

--- a/koala/image.ts
+++ b/koala/image.ts
@@ -27,7 +27,7 @@ export async function maybeGetCardImageUrl(
 
 const CHEAPNESS = 2;
 
-export async function maybeAddImageToCard(card: Card) {
+async function maybeAddImageToCard(card: Card) {
   if (Math.random() < 1 / CHEAPNESS) {
     // Only create images 1/6 of the time.
     return `Skipping ${card.term}`;

--- a/koala/is-approved-user.ts
+++ b/koala/is-approved-user.ts
@@ -2,7 +2,7 @@ import { prismaClient } from "@/koala/prisma-client";
 import { timeUntil } from "./time-until";
 
 // Users that are allowed to use GPT-4, etc..
-export const superUsers = (process.env.AUTHORIZED_EMAILS || "")
+const superUsers = (process.env.AUTHORIZED_EMAILS || "")
   .split(",")
   .filter((x: string) => x.includes("@"))
   .map((x: string) => x.trim().toLowerCase());

--- a/koala/openai.ts
+++ b/koala/openai.ts
@@ -54,11 +54,6 @@ const SIMPLE_YES_OR_NO = {
 };
 
 export type Explanation = { response: YesNo; whyNot?: string };
-export type YesOrNoInput = {
-  userInput: string;
-  question: string;
-  userID: string;
-};
 
 export const testEquivalence = async (
   left: string,

--- a/koala/quiz-evaluators/evaluator-utils.ts
+++ b/koala/quiz-evaluators/evaluator-utils.ts
@@ -5,11 +5,3 @@ export function strip(input: string): string {
   // \p{N} matches any kind of numeric character in any script
   return input.replace(/[\p{P}\s\p{N}]/gu, "").toLocaleLowerCase();
 }
-
-export const removeParens = (input: string): string => {
-  // Replace parents and double whitespace
-  return input
-    .replace(/\(.*?\)/g, "")
-    .replace(/\s{2,}/g, " ")
-    .trim();
-};

--- a/koala/quiz-evaluators/types.ts
+++ b/koala/quiz-evaluators/types.ts
@@ -1,7 +1,7 @@
 import { Quiz, Card } from "@prisma/client";
 import { QuizResult } from "../shared-types";
 
-export type QuizEvaluatorInput = {
+type QuizEvaluatorInput = {
   quiz: Quiz;
   card: Card;
   userInput: string;

--- a/koala/routes/bulk-create-cards.ts
+++ b/koala/routes/bulk-create-cards.ts
@@ -12,6 +12,7 @@ export const LANG_CODES = z.union([
 export const bulkCreateCards = procedure
   .input(
     z.object({
+      cardType: z.string(),
       langCode: LANG_CODES,
       input: z
         .array(
@@ -56,7 +57,16 @@ export const bulkCreateCards = procedure
           const card = await prismaClient.card.create({
             data,
           });
-          ["listening", "speaking"].map(async (quizType) => {
+          const DEFAULTS = ["listening", "speaking"];
+          const TYPES: Record<string, string[]> = {
+            listening: ["listening"],
+            speaking: ["speaking"],
+          };
+          const quizTypes = TYPES[input.cardType] || DEFAULTS;
+          console.log(
+            `=== CREATE QUIZES FOR ${quizTypes.sort().join(", ")} ===`,
+          );
+          quizTypes.map(async (quizType) => {
             await prismaClient.quiz.create({
               data: {
                 cardId: card.id,

--- a/koala/routes/grade-quiz.ts
+++ b/koala/routes/grade-quiz.ts
@@ -144,7 +144,6 @@ export const gradeQuiz = procedure
         return errorReport(`Unknown quiz type: ${quizType}`);
     }
     const transcript = await transcribeB64(
-      quiz.quizType === "listening" ? "en-US" : (card.langCode as "ko"),
       x.input.audio,
       user.id,
       prompt,

--- a/koala/routes/grade-quiz.ts
+++ b/koala/routes/grade-quiz.ts
@@ -143,11 +143,7 @@ export const gradeQuiz = procedure
       default:
         return errorReport(`Unknown quiz type: ${quizType}`);
     }
-    const transcript = await transcribeB64(
-      x.input.audio,
-      user.id,
-      prompt,
-    );
+    const transcript = await transcribeB64(x.input.audio, user.id, prompt);
     if (transcript.kind === "error") {
       return {
         result: "error",

--- a/koala/routes/transcribe-audio.ts
+++ b/koala/routes/transcribe-audio.ts
@@ -8,6 +8,7 @@ import { errorReport } from "../error-report";
 export const transcribeAudio = procedure
   .input(
     z.object({
+      targetText: z.string(),
       audio: z.string().max(1000000),
       lang: LANG_CODES,
     }),
@@ -19,7 +20,7 @@ export const transcribeAudio = procedure
   )
   .mutation(async ({ ctx, input }) => {
     const us = await getUserSettings(ctx.user?.id);
-    const result = await transcribeB64(input.lang, input.audio, us.userId);
+    const result = await transcribeB64(input.audio, us.userId, input.targetText);
 
     if (result.kind !== "OK") {
       return errorReport('result.kind !== "OK"');

--- a/koala/routes/transcribe-audio.ts
+++ b/koala/routes/transcribe-audio.ts
@@ -20,7 +20,11 @@ export const transcribeAudio = procedure
   )
   .mutation(async ({ ctx, input }) => {
     const us = await getUserSettings(ctx.user?.id);
-    const result = await transcribeB64(input.audio, us.userId, input.targetText);
+    const result = await transcribeB64(
+      input.audio,
+      us.userId,
+      input.targetText,
+    );
 
     if (result.kind !== "OK") {
       return errorReport('result.kind !== "OK"');

--- a/koala/storage.ts
+++ b/koala/storage.ts
@@ -14,7 +14,7 @@ if (!creds) {
   errorReport("Missing GCP_JSON_CREDS");
 }
 
-export const storage = new Storage({
+const storage = new Storage({
   projectId: creds.project_id,
   credentials: creds,
 });

--- a/koala/study_reducer.ts
+++ b/koala/study_reducer.ts
@@ -16,7 +16,7 @@ export type Quiz = {
   imageURL?: string;
 };
 
-export type Failure = {
+type Failure = {
   id: number;
   cardId: number;
   definition: string;

--- a/koala/time-until.ts
+++ b/koala/time-until.ts
@@ -32,8 +32,8 @@ const calculateDiff = (timestamp: number, now: number) => {
       // Order matters.
       years,
       days,
-      minutes,
       hours,
+      minutes,
       seconds,
     },
   };

--- a/koala/transcribe.ts
+++ b/koala/transcribe.ts
@@ -5,7 +5,6 @@ import { promisify } from "util";
 import { SafeCounter } from "./counter";
 import { errorReport } from "./error-report";
 import { openai } from "./openai";
-import { LangCode } from "./shared-types";
 
 export const captureAudio = (dataURI: string): string => {
   const regex = /^data:.+\/(.+);base64,(.*)$/;
@@ -18,25 +17,16 @@ export const captureAudio = (dataURI: string): string => {
 
 type TranscriptionResult = { kind: "OK"; text: string } | { kind: "error" };
 
-const PROMPTS: Record<string, string> = {
-  ko: "다양한 한국어 예문을 읽는 연습",
-  en: "Reading diverse example sentences in English ",
-  it: "Esercizio di lettura di frasi esemplificative in italiano",
-  fr: "Exercice de lecture de phrases d'exemple en français",
-  es: "Ejercicio de lectura de frases de ejemplo en español",
-};
-
 const transcriptionLength = SafeCounter({
   name: "transcriptionLength",
   help: "Number of characters transcribed.",
-  labelNames: ["lang", "userID"],
+  labelNames: ["userID"],
 });
 
 export async function transcribeB64(
-  lang: LangCode | "en-US",
   dataURI: string,
   userID: string | number,
-  prompt = PROMPTS[lang.slice(0, 2)] || PROMPTS.ko,
+  prompt: string,
 ): Promise<TranscriptionResult> {
   const writeFileAsync = promisify(writeFile);
   const base64Data = dataURI.split(";base64,").pop() || "";
@@ -56,7 +46,7 @@ export async function transcribeB64(
           prompt,
         });
         const text = y.text || "NO RESPONSE.";
-        transcriptionLength.labels({ lang, userID }).inc(y.text.length);
+        transcriptionLength.labels({ userID }).inc(y.text.length);
         return resolve({
           kind: "OK",
           text,

--- a/koala/transcribe.ts
+++ b/koala/transcribe.ts
@@ -3,17 +3,7 @@ import path from "path";
 import { uid } from "radash";
 import { promisify } from "util";
 import { SafeCounter } from "./counter";
-import { errorReport } from "./error-report";
 import { openai } from "./openai";
-
-export const captureAudio = (dataURI: string): string => {
-  const regex = /^data:.+\/(.+);base64,(.*)$/;
-  const matches = dataURI.match(regex);
-  if (!matches || matches.length !== 3) {
-    return errorReport("Invalid input string");
-  }
-  return matches[2];
-};
 
 type TranscriptionResult = { kind: "OK"; text: string } | { kind: "error" };
 

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -26,7 +26,8 @@ const server: EmailConfig["server"] = {
     pass: process.env.EMAIL_SERVER_PASSWORD || "",
   },
 };
-export const EMAIL_SERVER_OPTIONS: Partial<EmailUserConfig> = {
+
+const EMAIL_SERVER_OPTIONS: Partial<EmailUserConfig> = {
   server,
   from: process.env.EMAIL_FROM,
   generateVerificationToken() {

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -1,15 +1,16 @@
-import { useState, useReducer } from "react";
-import {
-  Stepper,
-  Select,
-  Textarea,
-  Button,
-  Group,
-  TextInput,
-  Container,
-} from "@mantine/core";
-import { trpc } from "@/koala/trpc-config";
 import { Gender, LangCode } from "@/koala/shared-types";
+import { trpc } from "@/koala/trpc-config";
+import {
+  Button,
+  Container,
+  Group,
+  Radio,
+  Select,
+  Stepper,
+  TextInput,
+  Textarea,
+} from "@mantine/core";
+import { useReducer, useState } from "react";
 type ProcessedCard = {
   term: string;
   definition: string;
@@ -22,18 +23,21 @@ type Action =
   | { type: "REMOVE_CARD"; index: number }
   | { type: "SET_LANGUAGE"; language: LangCode }
   | { type: "SET_PROCESSED_CARDS"; processedCards: ProcessedCard[] }
-  | { type: "SET_RAW_INPUT"; rawInput: string };
+  | { type: "SET_RAW_INPUT"; rawInput: string }
+  | { type: "SET_CARD_TYPE"; cardType: string };
 
 interface State {
   language: LangCode;
   rawInput: string;
   processedCards: ProcessedCard[];
+  cardType: string;
 }
 
 const INITIAL_STATE: State = {
   language: "ko",
   rawInput: "",
   processedCards: [],
+  cardType: "both",
 };
 
 const errorHandler = (error: any) => {
@@ -98,6 +102,8 @@ function reducer(state: State, action: Action): State {
       return { ...state, processedCards: action.processedCards };
     case "SET_RAW_INPUT":
       return { ...state, rawInput: action.rawInput };
+    case "SET_CARD_TYPE":
+      return { ...state, cardType: action.cardType };
     default:
       return state;
   }
@@ -145,6 +151,7 @@ function LanguageInputPage() {
       .mutateAsync({
         langCode: state.language,
         input: state.processedCards,
+        cardType: state.cardType,
       })
       .then(() => {
         // Reset and start over:
@@ -217,6 +224,25 @@ function LanguageInputPage() {
           </p>
           <Button size="xs" onClick={pasteExample}>
             Paste Example Input
+          </Button>
+        </Stepper.Step>
+        <Stepper.Step label="Set card type">
+          <Radio.Group
+            label="Select the type of cards"
+            value={state.cardType}
+            onChange={(value) =>
+              dispatch({ type: "SET_CARD_TYPE", cardType: value })
+            }
+          >
+            <Radio value="listening" label="Listening" />
+            <Radio value="speaking" label="Speaking" />
+            <Radio value="both" label="Both" />
+          </Radio.Group>
+          <Button
+            disabled={!state.cardType}
+            onClick={() => setActiveStep((current) => current + 1)}
+          >
+            Next
           </Button>
         </Stepper.Step>
         <Stepper.Step label="Edit cards">

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -234,9 +234,18 @@ function LanguageInputPage() {
               dispatch({ type: "SET_CARD_TYPE", cardType: value })
             }
           >
-            <Radio value="listening" label="Listening" />
-            <Radio value="speaking" label="Speaking" />
-            <Radio value="both" label="Both" />
+            <Radio
+              value="listening"
+              label="Listening only - Good for long sentences."
+            />
+            <Radio
+              value="speaking"
+              label="Speaking only - Good for single words and set words (colors, numbers)"
+            />
+            <Radio
+              value="both"
+              label="Both - Good for medium length phrases and sentences"
+            />
           </Radio.Group>
           <Button
             disabled={!state.cardType}

--- a/pages/mirror.tsx
+++ b/pages/mirror.tsx
@@ -24,6 +24,7 @@ export default function Mirror() {
       const { result: korean } = await transcribeAudio.mutateAsync({
         audio: base64Audio,
         lang: "ko",
+        targetText: "사람들이 한국말로 말해요."
       });
       setTranscription(korean);
 

--- a/pages/mirror.tsx
+++ b/pages/mirror.tsx
@@ -24,7 +24,7 @@ export default function Mirror() {
       const { result: korean } = await transcribeAudio.mutateAsync({
         audio: base64Audio,
         lang: "ko",
-        targetText: "사람들이 한국말로 말해요."
+        targetText: "사람들이 한국말로 말해요.",
       });
       setTranscription(korean);
 


### PR DESCRIPTION
The auto-flag experiment turned out to be too aggressive. I am trying a new experiment: reset difficult cards to 0.

Additionally:

 * BUG: Fix bug in timeuntil() helper
 * CHORE: emove dead code and unused imports.
 * FEATURE: Ability to add "listening only" and "speaking only" cards.