### PR TITLE
Remove CN, JP, TH Support :(

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Unlike traditional SRS apps that often rely on self-grading, KoalaCards provides
 ## Supported Languages
 
 *   **Officially Supported:** Korean, French, Italian, Spanish
-*   **Untested/Limited Support:** Arabic, Catalan, Chinese, Czech, Danish, Dutch, English, Finnish, Galician, German, Greek, Gujarati, Hebrew, Hindi, Hungarian, Indonesian, Japanese, Kannada, Latvian, Lithuanian, Malay, Marathi, Norwegian, Polish, Portuguese, Punjabi, Romanian, Russian, Serbian, Slovak, Swedish, Thai, Turkish, Ukrainian, Vietnamese
+*   **Untested/Limited Support:** Arabic, Catalan, Czech, Danish, Dutch, English, Finnish, Galician, German, Greek, Gujarati, Hebrew, Hindi, Hungarian, Indonesian, Kannada, Latvian, Lithuanian, Malay, Marathi, Norwegian, Polish, Portuguese, Punjabi, Romanian, Russian, Serbian, Slovak, Swedish, Turkish, Ukrainian, Vietnamese
 
 *Note: While multiple languages are supported, the primary focus is English speakers learning Korean.*
 

--- a/koala/components/InputStep.tsx
+++ b/koala/components/InputStep.tsx
@@ -72,11 +72,13 @@ export function InputStep({
         </Text>
 
         <Text size="sm" c={theme.colors.gray[7]} mb="md">
-          <b>Koala is built for self-study learners who have a textbook or
-          language course to follow.</b> If you don't have material of your
-          own, that's OK. Koala can generate content for you to study.
-          Click the button below until you find a topic that is interesting
-          to you.
+          <b>
+            Koala is built for self-study learners who have a textbook or
+            language course to follow.
+          </b>{" "}
+          If you don't have material of your own, that's OK. Koala can
+          generate content for you to study. Click the button below until
+          you find a topic that is interesting to you.
         </Text>
 
         <Button

--- a/koala/generate-speech-url.ts
+++ b/koala/generate-speech-url.ts
@@ -27,16 +27,6 @@ const Voices: LangLookTable = {
       "ar-XA-Wavenet-D",
     ],
   },
-  cn: {
-    F: ["cmn-CN-Wavenet-A", "cmn-CN-Wavenet-D"],
-    M: ["cmn-CN-Wavenet-B", "cmn-CN-Wavenet-C"],
-    N: [
-      "cmn-CN-Wavenet-A",
-      "cmn-CN-Wavenet-B",
-      "cmn-CN-Wavenet-C",
-      "cmn-CN-Wavenet-D",
-    ],
-  },
   he: {
     F: ["he-IL-Wavenet-A", "he-IL-Wavenet-C"],
     M: ["he-IL-Wavenet-B", "he-IL-Wavenet-D"],
@@ -68,13 +58,6 @@ const Voices: LangLookTable = {
       "tr-TR-Wavenet-D",
       "tr-TR-Wavenet-E",
     ],
-  },
-  th: {
-    F: ["th-TH-Standard-A"],
-    M: [
-      "th-TH-Standard-A", // THIS IS NOT ACTUALLY A MALE VOICE. NO MALE OPTION AVAILABLE.
-    ],
-    N: ["th-TH-Standard-A"],
   },
   en: {
     F: ["en-US-Wavenet-C"],
@@ -195,16 +178,6 @@ const Voices: LangLookTable = {
       "id-ID-Wavenet-B",
       "id-ID-Wavenet-C",
       "id-ID-Wavenet-D",
-    ],
-  },
-  ja: {
-    F: ["ja-JP-Wavenet-A", "ja-JP-Wavenet-C"],
-    M: ["ja-JP-Wavenet-B", "ja-JP-Wavenet-D"],
-    N: [
-      "ja-JP-Wavenet-A",
-      "ja-JP-Wavenet-B",
-      "ja-JP-Wavenet-C",
-      "ja-JP-Wavenet-D",
     ],
   },
   ms: {

--- a/koala/shared-types.ts
+++ b/koala/shared-types.ts
@@ -4,7 +4,6 @@ export type Gender = "M" | "F" | "N";
 export type LangCode =
   | "ar" // Arabic
   | "ca" // Catalan
-  | "cn" // Chinese
   | "cs" // Czech
   | "da" // Danish
   | "de" // German
@@ -20,7 +19,6 @@ export type LangCode =
   | "hu" // Hungarian
   | "id" // Indonesian
   | "it" // Italian
-  | "ja" // Japanese
   | "kn" // Kannada
   | "ko" // Korean
   | "lt" // Lithuanian
@@ -37,10 +35,9 @@ export type LangCode =
   | "sk" // Slovak
   | "sr" // Serbian
   | "sv" // Swedish
-  | "th"
   | "tr" // Turkish
   | "uk" // Ukrainian
-  | "vi"; // Vietnamese // Thai
+  | "vi"; // Vietnamese
 export type LessonType = "listening" | "speaking" | "dictation" | "review";
 export type QuizResult = "error" | "fail" | "pass";
 export type YesNo = "yes" | "no";
@@ -48,7 +45,6 @@ export type YesNo = "yes" | "no";
 export const LANG_CODES = z.union([
   z.literal("ar"),
   z.literal("ca"),
-  z.literal("cn"),
   z.literal("cs"),
   z.literal("da"),
   z.literal("de"),
@@ -64,7 +60,6 @@ export const LANG_CODES = z.union([
   z.literal("hu"),
   z.literal("id"),
   z.literal("it"),
-  z.literal("ja"),
   z.literal("kn"),
   z.literal("ko"),
   z.literal("lt"),
@@ -81,7 +76,6 @@ export const LANG_CODES = z.union([
   z.literal("sk"),
   z.literal("sr"),
   z.literal("sv"),
-  z.literal("th"),
   z.literal("tr"),
   z.literal("uk"),
   z.literal("vi"),
@@ -90,7 +84,6 @@ export const LANG_CODES = z.union([
 export const supportedLanguages: Record<LangCode, string> = {
   ar: "Arabic",
   ca: "Catalan",
-  cn: "Chinese",
   cs: "Czech",
   da: "Danish",
   de: "German",
@@ -106,7 +99,6 @@ export const supportedLanguages: Record<LangCode, string> = {
   hu: "Hungarian",
   id: "Indonesian",
   it: "Italian",
-  ja: "Japanese",
   kn: "Kannada",
   ko: "Korean",
   lt: "Lithuanian",
@@ -123,7 +115,6 @@ export const supportedLanguages: Record<LangCode, string> = {
   sk: "Slovak",
   sr: "Serbian",
   sv: "Swedish",
-  th: "Thai",
   tr: "Turkish",
   uk: "Ukrainian",
   vi: "Vietnamese",

--- a/pages/frequency-lists.tsx
+++ b/pages/frequency-lists.tsx
@@ -71,18 +71,6 @@ const frequencyListsData: LanguageData[] = [
     ],
   },
   {
-    name: "Mandarin Chinese",
-    lists: [
-      {
-        title: "Mandarin Word Frequency List (Academia Sinica, 10k Words)",
-        description:
-          "A frequency list of the 10,000 most common Mandarin words used in modern Taiwanese Mandarin. This list was compiled by Academia Sinica (CKIP group).",
-        url: "https://en.wiktionary.org/wiki/Appendix:Mandarin_Frequency_lists",
-        source: "Academia Sinica Mandarin corpus (10k words)",
-      },
-    ],
-  },
-  {
     name: "Italian",
     lists: [
       {
@@ -98,18 +86,6 @@ const frequencyListsData: LanguageData[] = [
           "For a quick view, Wiktionary also provides the top 1,000 Italian words from subtitles, derived from a 5.6 million-word subtitle corpus (movies/TV, compiled in 2008).",
         url: "https://en.wiktionary.org/wiki/Wiktionary:Frequency_lists/Italian1000",
         source: "Italian subtitles corpus (5.6M words, 2008)",
-      },
-    ],
-  },
-  {
-    name: "Japanese",
-    lists: [
-      {
-        title: "Japanese Wikipedia Frequency Lists",
-        description:
-          "Frequency lists drawn from Japanese Wikipedia dumps (2013 and 2022). These lists provide rankings of high-frequency Japanese words in current use on Wikipedia.",
-        url: "https://en.wiktionary.org/wiki/Wiktionary:Frequency_lists/Japanese",
-        source: "Japanese Wikipedia corpus (2013, 2022)",
       },
     ],
   },

--- a/pages/review.tsx
+++ b/pages/review.tsx
@@ -135,7 +135,7 @@ export default function ReviewPage({ decks }: ReviewPageProps) {
   function DeckCard({ deck }: { deck: DeckWithReviewInfo }) {
     const [isEditing, setIsEditing] = useState(false);
     const [title, setTitle] = useState(deck.name);
-    const take = 7; // Hard-coded to 7 cards
+    const take = 4;
     const updateDeckMutation = trpc.updateDeck.useMutation();
     const deleteDeckMutation = trpc.deleteDeck.useMutation();
 

--- a/prisma/migrations/20250525124758_change_defaults/migration.sql
+++ b/prisma/migrations/20250525124758_change_defaults/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "UserSettings" ALTER COLUMN "cardsPerDayMax" SET DEFAULT 7,
+ALTER COLUMN "playbackPercentage" SET DEFAULT 0.125,
+ALTER COLUMN "dailyWritingGoal" SET DEFAULT 150;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,13 +61,13 @@ model UserSettings {
   // Audio playback speed min: 0.5 max: 2
   playbackSpeed      Float    @default(1)
   // Cards/day max
-  cardsPerDayMax     Int      @default(21)
+  cardsPerDayMax     Int      @default(7)
   // Value from 0 to 1 representing the percentage liklihood
   // of a random playback of the user's audio.
-  playbackPercentage Float    @default(1)
+  playbackPercentage Float    @default(0.125)
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
-  dailyWritingGoal   Int      @default(500) // Default goal of 500 characters
+  dailyWritingGoal   Int      @default(150)
   writingFirst       Boolean  @default(false) // Always quiz writing before reviewing cards
 }
 


### PR DESCRIPTION
I don't have time to look into a token parser for these languages. For now, I only support leanguages that:

1. Have voices available on Google Cloud
2. Have OpenAI support
3. Use whitespace to delimit words (need this for things like remix and writing helper)